### PR TITLE
fix for 2.5

### DIFF
--- a/lib/export_csv_file_extension.rb
+++ b/lib/export_csv_file_extension.rb
@@ -256,12 +256,12 @@ module ExtendedDownloadExportExtension
     end
   end
 
-  def get_header
-    if (@entity === 'user_archive' && SiteSetting.legal_extended_user_download) ||
-       (@entity === 'admin_user_archive' && SiteSetting.legal_extended_user_download_admin)
+  def get_header(entity)
+    if (entity === 'user_archive' && SiteSetting.legal_extended_user_download) ||
+       (entity === 'admin_user_archive' && SiteSetting.legal_extended_user_download_admin)
       extended_header
     else
-      super
+      super(entity)
     end
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: discourse-legal-tools
 # about: Tools to help with legal compliance when using Discourse
-# version: 0.1
+# version: 2.5.0
 # author: Angus McLeod
 
 load File.expand_path('../models/legal_extended_user_download_admin_site_setting.rb', __FILE__)


### PR DESCRIPTION
get_header now has an argument and report is not an instance variable any more.