### PR TITLE
FIX: Don't use `Discourse.User`

### DIFF
--- a/assets/javascripts/discourse/connectors/admin-user-controls-after/download-all-wrapper.js.es6
+++ b/assets/javascripts/discourse/connectors/admin-user-controls-after/download-all-wrapper.js.es6
@@ -3,7 +3,7 @@ import { exportEntity } from 'discourse/lib/export-csv';
 export default {
   setupComponent(attrs, component) {
     const setting = Discourse.SiteSettings.legal_extended_user_download_admin;
-    const user = Discourse.User.current();
+    const user = component.currentUser;
     const allowed = (function(setting) {
       switch(setting) {
         case 'disabled':


### PR DESCRIPTION
It's been deprecated for some time and will be broken shortly.