### PR TITLE
Remove deprecated require_dependency

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: discourse-legal-tools
 # about: Tools to help with legal compliance when using Discourse
-# version: 0.2
+# version: 0.2.1
 # required_version: 2.5.0
 # author: Angus McLeod
 # url: https://github.com/paviliondev/discourse-legal-tools
@@ -10,7 +10,6 @@ load File.expand_path('../models/legal_extended_user_download_admin_site_setting
 after_initialize do
   load File.expand_path('../lib/export_csv_file_extension.rb', __FILE__)
 
-  require_dependency 'jobs/regular/export_csv_file'
   class Jobs::ExportCsvFile
     prepend ExtendedDownloadExportExtension
   end


### PR DESCRIPTION
https://github.com/discourse/discourse/commit/5743a6ec1e5dfb9ef2415b09dc6cdd412edba8b9 broke this plugin.

```
LoadError: cannot load such file -- jobs/regular/export_csv_file
/var/www/discourse/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:15:in `require'
/var/www/discourse/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:15:in `require'
/var/www/discourse/vendor/bundle/ruby/2.7.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
/var/www/discourse/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.4.7/lib/active_support/dependencies/zeitwerk_integration.rb:51:in `require_dependency'
/var/www/discourse/lib/require_dependency_backward_compatibility.rb:18:in `require_dependency'
/var/www/discourse/plugins/discourse-legal-tools/plugin.rb:13:in `block in activate!'

```

`require_dependency` is not needed anymore, it should be removed.