### PR TITLE
Add pluginId to modifyClass()

### DIFF
--- a/assets/javascripts/discourse/initializers/legal-edits.js.es6
+++ b/assets/javascripts/discourse/initializers/legal-edits.js.es6
@@ -6,6 +6,7 @@ export default {
   initialize() {
     withPluginApi('0.8.12', api => {
       api.modifyClass('controller:user-activity', {
+        pluginId: 'discourse-legal-tools',
         actions: {
           exportUserArchive() {
             const extendedUserDownload = this.siteSettings.legal_extended_user_download;


### PR DESCRIPTION
Suppress warning `[PLUGIN discourse-legal-tools] To prevent errors in tests, add a pluginId key to your modifyClass call. `